### PR TITLE
Add dev docker environment

### DIFF
--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - "17103:3306"
     php:
-        image: ilios/php
+        image: ilios/php-dev
         expose:
             - "9000"
     web:

--- a/php-fpm-dev/Dockerfile
+++ b/php-fpm-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ilios/php:v3.26.0
+FROM ilios/php:latest
 
 MAINTAINER Ilios Project Team <support@iliosproject.org>
 


### PR DESCRIPTION
Use the php image for the demo environment and add a dev environment
that users php-dev at the latest commit.  This is useful for working
with the API at the latest version when developing the frontend.