### PR TITLE
Don't clear environmental variables

### DIFF
--- a/php-fpm/php-fpm.conf
+++ b/php-fpm/php-fpm.conf
@@ -10,6 +10,7 @@ include = /etc/php7/fpm.d/*.conf
 
 [global]
 error_log = /var/log/php-fpm.log
+clear_env = no
 
 ;;;;;;;;;;;;;;;;;;;;
 ; Pool Definitions ;


### PR DESCRIPTION
Without this it is impossible to pass variables from the shell into PHP.
Which makes it impossible to correctly configure containers from the
outside.