### PR TITLE
Fix to php-fpm configuration

### DIFF
--- a/php-fpm/php-fpm.conf
+++ b/php-fpm/php-fpm.conf
@@ -10,7 +10,6 @@ include = /etc/php7/fpm.d/*.conf
 
 [global]
 error_log = /var/log/php-fpm.log
-clear_env = no
 
 ;;;;;;;;;;;;;;;;;;;;
 ; Pool Definitions ;
@@ -25,3 +24,4 @@ pm.max_children = 20
 pm.min_spare_servers = 2
 pm.max_spare_servers = 3
 pm.start_servers = 2;
+clear_env = no

--- a/php-fpm/php-fpm.conf
+++ b/php-fpm/php-fpm.conf
@@ -23,5 +23,5 @@ pm = dynamic
 pm.max_children = 20
 pm.min_spare_servers = 2
 pm.max_spare_servers = 3
-pm.start_servers = 2;
+pm.start_servers = 2
 clear_env = no


### PR DESCRIPTION
This is a pool configuration directive not a global option

Original Purpose:
Don't clear environmental variables
Without this it is impossible to pass variables from the shell into
PHP. Which makes it impossible to correctly configure containers from the outside.