### PR TITLE
Allow larger GET requests

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
   open_file_cache max=100;
   fastcgi_buffers 16 16k;
   fastcgi_buffer_size 32k;
+  large_client_header_buffers 4 16k;
 }
 
 daemon off;


### PR DESCRIPTION
This doubles the default limit for URL length which allows the API to be
hit for larger data sets.

Refs https://github.com/ilios/frontend/issues/3385