### PR TITLE
Create an SSH server ilios container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   - env: BUILD=mysql
   - env: BUILD=mysql-demo
   - env: BUILD=php-apache-dev
+  - env: BUILD=ssh-admin
 
 env:
   matrix:

--- a/ssh-admin/Dockerfile
+++ b/ssh-admin/Dockerfile
@@ -1,0 +1,25 @@
+FROM ilios/php-apache:v3.67.0
+
+MAINTAINER Ilios Project Team <support@iliosproject.org>
+
+RUN apt-get update && \
+    apt-get install -y wget openssh-server sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y
+
+# This doesn't get created automatically, don't know why
+RUN mkdir /run/sshd
+
+# Remove password based authentication for SSH
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+# allow users in the sudo group to do wo without a password
+RUN /bin/echo "%sudo ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/no-password-group
+
+# Copy and run our user creation script
+ARG GITHUB_ACCOUNT_SSH_USERS=''
+COPY add-ssh-users.sh /tmp/add-ssh-users.sh
+RUN /bin/bash /tmp/add-ssh-users.sh
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/ssh-admin/add-ssh-users.sh
+++ b/ssh-admin/add-ssh-users.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euf -o pipefail
+
+if [[ $GITHUB_ACCOUNT_SSH_USERS ]]; then
+	# keep a copy of the default file seperator
+	ORIGINAL_IFS=$IFS
+
+	# Users are sperated with semi-colons
+	IFS=';'
+	for user in $GITHUB_ACCOUNT_SSH_USERS
+	do
+			SSH_DIR="/home/$user/.ssh"
+			/usr/sbin/useradd -ms /bin/bash -G sudo $user
+			/bin/mkdir $SSH_DIR
+			/usr/bin/wget -O - "https://github.com/${user}.keys" >> "${SSH_DIR}/authorized_keys"
+			/bin/chown -R "${user}:${user}" $SSH_DIR
+			/bin/chmod 700 $SSH_DIR
+			/bin/chmod 600 "${SSH_DIR}/authorized_keys"
+	done
+
+	IFS=$ORIGINAL_IFS
+fi


### PR DESCRIPTION
This still has the PHP and Apache base, but it only runs and exposes an
SSH server to which users are added by specifying
GITHUB_ACCOUNT_SSH_USERS as a built time argument. This semi-colon
separated list takes the public keys for a users github account and
creates a login.  Each user is given passwordless sudo so they can
perform ilios administrative tasks on this machine.