### PR TITLE
Setup ssh users on boot

### DIFF
--- a/ssh-admin/Dockerfile
+++ b/ssh-admin/Dockerfile
@@ -2,6 +2,9 @@ FROM ilios/php-apache:v3
 
 MAINTAINER Ilios Project Team <support@iliosproject.org>
 
+# semi-colon seperates list of github users that can SSH in
+ENV GITHUB_ACCOUNT_SSH_USERS=''
+
 RUN apt-get update && \
     apt-get install -y wget openssh-server sudo netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -16,12 +19,9 @@ RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/s
 # allow users in the sudo group to do wo without a password
 RUN /bin/echo "%sudo ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/no-password-group
 
-# Copy and run our user creation script
-ARG GITHUB_ACCOUNT_SSH_USERS=''
-COPY add-ssh-users.sh /tmp/add-ssh-users.sh
-RUN /bin/bash /tmp/add-ssh-users.sh
+COPY entrypoint.sh /entrypoint.sh
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+ENTRYPOINT /entrypoint.sh
 
 HEALTHCHECK CMD nc -vz 127.0.0.1 22 || exit 1

--- a/ssh-admin/entrypoint.sh
+++ b/ssh-admin/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euf -o pipefail
 
+/bin/echo "Entrypoint ssh-admin container"
+
 if [[ $GITHUB_ACCOUNT_SSH_USERS ]]; then
 	# keep a copy of the default file seperator
 	ORIGINAL_IFS=$IFS
@@ -9,10 +11,11 @@ if [[ $GITHUB_ACCOUNT_SSH_USERS ]]; then
 	IFS=';'
 	for user in $GITHUB_ACCOUNT_SSH_USERS
 	do
+			/bin/echo "Creating account for user ${user}"
 			SSH_DIR="/home/$user/.ssh"
 			/usr/sbin/useradd -ms /bin/bash -G sudo $user
 			/bin/mkdir $SSH_DIR
-			/usr/bin/wget -O - "https://github.com/${user}.keys" >> "${SSH_DIR}/authorized_keys"
+			/usr/bin/wget --quiet -O - "https://github.com/${user}.keys" >> "${SSH_DIR}/authorized_keys"
 			/bin/chown -R "${user}:${user}" $SSH_DIR
 			/bin/chmod 700 $SSH_DIR
 			/bin/chmod 600 "${SSH_DIR}/authorized_keys"
@@ -20,3 +23,7 @@ if [[ $GITHUB_ACCOUNT_SSH_USERS ]]; then
 
 	IFS=$ORIGINAL_IFS
 fi
+
+/bin/echo "Starting ssh server"
+
+/usr/sbin/sshd -D


### PR DESCRIPTION
This makes it possible to use the existing build without needing our own
ssh-admin container with it's own runtime.