### PR TITLE
Update mysql package name

### DIFF
--- a/ssh-admin/Dockerfile
+++ b/ssh-admin/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Ilios Project Team <support@iliosproject.org>
 ENV GITHUB_ACCOUNT_SSH_USERS=''
 
 RUN apt-get update && \
-    apt-get install -y wget openssh-server sudo netcat mysql-client vim telnet && \
+    apt-get install -y wget openssh-server sudo netcat default-mysql-client vim telnet && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y
 


### PR DESCRIPTION
Our PHP 7.4 ilios-php-apache image is now based on Debian Buster and the
mysql client package name was changed.